### PR TITLE
Remove redundant check for m_at

### DIFF
--- a/include/Sailboat.tci
+++ b/include/Sailboat.tci
@@ -106,7 +106,7 @@ namespace Sailboat {
     template <typename ...Ts> const typename traits::tw_traits<Ts...>::value_type Tween<Ts...>::step(int by, bool suppress_cb) {
         m_at += by;
         auto it = std::lower_bound(m_points.begin(), m_points.end(), m_at);
-        if (by >= 0 ? it == m_points.end() : m_at < 0) return m_values;
+        if (by >= 0 && it == m_points.end()) return m_values;
 
         detail::Point<Ts...> prev = *(it - 1), next = *(it);
         ease<0, Ts...>(prev.values, next.values, m_at - prev.at, next.delays, next.durations, next.easings, m_values);


### PR DESCRIPTION
Since m_at is of type std::size_t, it will never be < 0. This patch simplifies the ternary operator into a simple &&.