### PR TITLE
Add on_finish_cb callback

### DIFF
--- a/include/Sailboat.h
+++ b/include/Sailboat.h
@@ -67,6 +67,9 @@ namespace Sailboat {
 
             std::vector<detail::Point<Ts...>> m_points;
             typename m_traits::callback_type on_step_cb {NULL};
+            typename m_traits::callback_type on_finish_cb {NULL};
+
+            bool finish_callback_called {false};
             std::size_t m_length {0};
             std::size_t m_at {0};
         public:
@@ -83,6 +86,7 @@ namespace Sailboat {
 
             inline const typename m_traits::value_type step(int by = 1, bool suppress_cb = false);
             inline Tween<Ts...>& on_step(typename m_traits::callback_type&& func);
+            inline Tween<Ts...>& on_finish(typename m_traits::callback_type&& func);
 
             inline const typename m_traits::value_type seek(std::size_t at);
             inline std::size_t length();

--- a/include/Sailboat.tci
+++ b/include/Sailboat.tci
@@ -106,7 +106,13 @@ namespace Sailboat {
     template <typename ...Ts> const typename traits::tw_traits<Ts...>::value_type Tween<Ts...>::step(int by, bool suppress_cb) {
         m_at += by;
         auto it = std::lower_bound(m_points.begin(), m_points.end(), m_at);
-        if (by >= 0 ? it == m_points.end() : m_at < 0) return m_values;
+        if (by >= 0 && it == m_points.end()) {
+            if (!finish_callback_called && !suppress_cb && on_finish_cb != NULL) {
+                finish_callback_called = true;
+                call(on_finish_cb, m_values, detail::gen_seq<sizeof...(Ts)>());
+            }
+            return m_values;
+        }
 
         detail::Point<Ts...> prev = *(it - 1), next = *(it);
         ease<0, Ts...>(prev.values, next.values, m_at - prev.at, next.delays, next.durations, next.easings, m_values);
@@ -118,6 +124,11 @@ namespace Sailboat {
 
     template <typename ...Ts> inline Tween<Ts...>& Tween<Ts...>::on_step(typename m_traits::callback_type&& func) {
         if (func != NULL) on_step_cb = func;
+        return *this;
+    }
+
+    template <typename ...Ts> inline Tween<Ts...>& Tween<Ts...>::on_finish(typename m_traits::callback_type&& func) {
+        if (func != NULL) on_finish_cb = func;
         return *this;
     }
 


### PR DESCRIPTION
on_finish_cb functions similarly to on_step_cb, except it is only called once at the very last step (or when jumped or waited to that point).

Also remove redundant check for m_at, since it is of an unsigned type it can never be negative.