### PR TITLE
Add missing include to <algorithm>

### DIFF
--- a/include/Sailboat.tci
+++ b/include/Sailboat.tci
@@ -3,6 +3,8 @@
 
 #include "Sailboat.h"
 
+#include <algorithm>
+
 namespace Sailboat {
     namespace detail {
         template <typename ...Ts> bool Point<Ts...>::operator < (int i) { return i > at; }


### PR DESCRIPTION
Currently Sailboat.tci uses std::max_element which is defined in <algorithm>, but never includes it.